### PR TITLE
Add numerology web interface and calculations

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Numerology Explorer</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="page-header">
+    <h1>Numerology Explorer</h1>
+    <p>Discover your core numbers and daily influences with ease.</p>
+  </header>
+
+  <main class="layout">
+    <section class="card inputs">
+      <h2>Profile Details</h2>
+      <label class="field">
+        <span>Full Name</span>
+        <input type="text" id="fullName" placeholder="e.g., Ada Lovelace" />
+      </label>
+      <label class="field">
+        <span>Date of Birth</span>
+        <input type="date" id="birthDate" />
+      </label>
+      <label class="field">
+        <span>Calculation System</span>
+        <select id="systemToggle">
+          <option value="pythagorean">Pythagorean</option>
+          <option value="chaldean">Chaldean</option>
+        </select>
+      </label>
+      <label class="field">
+        <span>Calendar Date</span>
+        <input type="date" id="selectedDate" />
+      </label>
+    </section>
+
+    <section class="card results">
+      <h2>Core Numbers</h2>
+      <div class="result-grid">
+        <div class="result-item">
+          <span class="result-label">Life Path</span>
+          <output id="lifePath">—</output>
+        </div>
+        <div class="result-item">
+          <span class="result-label">Birth Day</span>
+          <output id="birthDay">—</output>
+        </div>
+        <div class="result-item">
+          <span class="result-label">Expression</span>
+          <output id="expression">—</output>
+        </div>
+        <div class="result-item">
+          <span class="result-label">Heart&#39;s Desire</span>
+          <output id="heartsDesire">—</output>
+        </div>
+        <div class="result-item">
+          <span class="result-label">Personality</span>
+          <output id="personality">—</output>
+        </div>
+      </div>
+    </section>
+
+    <section class="card calendar">
+      <h2>Calendar Insights</h2>
+      <div class="result-grid">
+        <div class="result-item">
+          <span class="result-label">Universal Year</span>
+          <output id="universalYear">—</output>
+        </div>
+        <div class="result-item">
+          <span class="result-label">Universal Month</span>
+          <output id="universalMonth">—</output>
+        </div>
+        <div class="result-item">
+          <span class="result-label">Personal Year</span>
+          <output id="personalYear">—</output>
+        </div>
+        <div class="result-item">
+          <span class="result-label">Personal Month</span>
+          <output id="personalMonth">—</output>
+        </div>
+        <div class="result-item">
+          <span class="result-label">Life Path of the Day</span>
+          <output id="lifePathOfDay">—</output>
+        </div>
+        <div class="result-item">
+          <span class="result-label">Selected Date</span>
+          <output id="selectedDateDisplay">—</output>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="page-footer">
+    <p>Built for numerology explorations &mdash; update any field to refresh the insights.</p>
+  </footer>
+
+  <script type="module" src="../src/app.js"></script>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,140 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background-color: #f5f6f8;
+  color: #1f2933;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.page-header,
+.page-footer {
+  text-align: center;
+  padding: 2rem 1.5rem;
+  background: white;
+  box-shadow: 0 2px 12px rgba(15, 23, 42, 0.08);
+  margin: 0;
+}
+
+.page-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(2rem, 5vw, 2.6rem);
+}
+
+.page-header p {
+  margin: 0;
+  color: #4b5563;
+  font-size: 1rem;
+}
+
+.layout {
+  width: min(1100px, 92vw);
+  margin: 2.5rem auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.card {
+  background: white;
+  border-radius: 18px;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  box-shadow: 0 20px 40px -24px rgba(15, 23, 42, 0.35);
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  letter-spacing: 0.02em;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.field input,
+.field select {
+  padding: 0.65rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid #d1d5db;
+  font: inherit;
+  background-color: #f9fafb;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input:focus,
+.field select:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+  background-color: #ffffff;
+}
+
+.result-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.result-item {
+  padding: 1rem;
+  border-radius: 12px;
+  background: #f9fafb;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-start;
+}
+
+.result-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6b7280;
+}
+
+output {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #1d4ed8;
+}
+
+.page-footer {
+  font-size: 0.9rem;
+  color: #64748b;
+  border-top-left-radius: 18px;
+  border-top-right-radius: 18px;
+  margin-top: auto;
+}
+
+@media (max-width: 640px) {
+  .page-header,
+  .page-footer {
+    padding: 1.5rem 1rem;
+  }
+
+  .card {
+    padding: 1.5rem;
+  }
+
+  output {
+    font-size: 1.25rem;
+  }
+}

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,99 @@
+import {
+  calculateBirthDay,
+  calculateExpression,
+  calculateHeartsDesire,
+  calculateLifePath,
+  calculateLifePathOfDay,
+  calculatePersonalMonth,
+  calculatePersonalYear,
+  calculatePersonality,
+  calculateSelectedDateLabel,
+  calculateUniversalMonth,
+  calculateUniversalYear
+} from './numerology/calculations.js';
+
+const elements = {
+  fullName: document.getElementById('fullName'),
+  birthDate: document.getElementById('birthDate'),
+  systemToggle: document.getElementById('systemToggle'),
+  selectedDate: document.getElementById('selectedDate'),
+  lifePath: document.getElementById('lifePath'),
+  birthDay: document.getElementById('birthDay'),
+  expression: document.getElementById('expression'),
+  heartsDesire: document.getElementById('heartsDesire'),
+  personality: document.getElementById('personality'),
+  universalYear: document.getElementById('universalYear'),
+  universalMonth: document.getElementById('universalMonth'),
+  personalYear: document.getElementById('personalYear'),
+  personalMonth: document.getElementById('personalMonth'),
+  lifePathOfDay: document.getElementById('lifePathOfDay'),
+  selectedDateDisplay: document.getElementById('selectedDateDisplay')
+};
+
+function formatDateInput(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function parseDate(value) {
+  if (!value) return null;
+  const [year, month, day] = value.split('-').map(Number);
+  if (!year || !month || !day) return null;
+  return new Date(year, month - 1, day);
+}
+
+function displayValue(node, value) {
+  node.textContent = value ?? '—';
+}
+
+function updateCalculations() {
+  const system = elements.systemToggle.value;
+  const nameRaw = elements.fullName.value || '';
+  const hasNameLetters = /[a-zA-Z]/.test(nameRaw);
+  const birthDate = parseDate(elements.birthDate.value);
+  const selectedDate = parseDate(elements.selectedDate.value) || new Date();
+
+  const lifePath = birthDate ? calculateLifePath(birthDate) : null;
+  const birthDay = birthDate ? calculateBirthDay(birthDate) : null;
+  const expression = hasNameLetters ? calculateExpression(nameRaw, system) : null;
+  const heartsDesire = hasNameLetters ? calculateHeartsDesire(nameRaw, system) : null;
+  const personality = hasNameLetters ? calculatePersonality(nameRaw, system) : null;
+
+  const universalYear = calculateUniversalYear(selectedDate);
+  const universalMonth = calculateUniversalMonth(selectedDate);
+  const personalYear = birthDate ? calculatePersonalYear(birthDate, selectedDate) : null;
+  const personalMonth = birthDate ? calculatePersonalMonth(birthDate, selectedDate) : null;
+  const lifePathOfDay = birthDate ? calculateLifePathOfDay(birthDate, selectedDate) : null;
+
+  displayValue(elements.lifePath, lifePath);
+  displayValue(elements.birthDay, birthDay);
+  displayValue(elements.expression, expression);
+  displayValue(elements.heartsDesire, heartsDesire);
+  displayValue(elements.personality, personality);
+
+  displayValue(elements.universalYear, universalYear);
+  displayValue(elements.universalMonth, universalMonth);
+  displayValue(elements.personalYear, personalYear);
+  displayValue(elements.personalMonth, personalMonth);
+  displayValue(elements.lifePathOfDay, lifePathOfDay);
+  displayValue(elements.selectedDateDisplay, calculateSelectedDateLabel(selectedDate));
+}
+
+function init() {
+  const today = new Date();
+  elements.selectedDate.value = formatDateInput(today);
+  if (!elements.birthDate.value) {
+    elements.birthDate.value = formatDateInput(today);
+  }
+
+  updateCalculations();
+
+  elements.fullName.addEventListener('input', updateCalculations);
+  elements.birthDate.addEventListener('change', updateCalculations);
+  elements.systemToggle.addEventListener('change', updateCalculations);
+  elements.selectedDate.addEventListener('change', updateCalculations);
+}
+
+init();

--- a/src/numerology/calculations.js
+++ b/src/numerology/calculations.js
@@ -1,0 +1,166 @@
+const SYSTEMS = {
+  pythagorean: {
+    name: 'Pythagorean',
+    values: {
+      A: 1, B: 2, C: 3, D: 4, E: 5, F: 6, G: 7, H: 8, I: 9,
+      J: 1, K: 2, L: 3, M: 4, N: 5, O: 6, P: 7, Q: 8, R: 9,
+      S: 1, T: 2, U: 3, V: 4, W: 5, X: 6, Y: 7, Z: 8
+    }
+  },
+  chaldean: {
+    name: 'Chaldean',
+    values: {
+      A: 1, B: 2, C: 3, D: 4, E: 5, F: 8, G: 3, H: 5, I: 1,
+      J: 1, K: 2, L: 3, M: 4, N: 5, O: 7, P: 8, Q: 1, R: 2,
+      S: 3, T: 4, U: 6, V: 6, W: 6, X: 5, Y: 1, Z: 7
+    }
+  }
+};
+
+const MASTER_NUMBERS = new Set([11, 22, 33]);
+
+function sanitizeLetters(input) {
+  return (input || '').toUpperCase().replace(/[^A-Z]/g, '');
+}
+
+function sumDigits(value) {
+  return value
+    .toString()
+    .split('')
+    .reduce((sum, digit) => sum + Number(digit), 0);
+}
+
+function reduceNumber(value) {
+  let current = typeof value === 'number' ? Math.abs(value) : Number(String(value).replace(/\D/g, ''));
+
+  while (current > 9 && !MASTER_NUMBERS.has(current)) {
+    current = sumDigits(current);
+  }
+
+  return current;
+}
+
+function letterValue(letter, system) {
+  const map = SYSTEMS[system]?.values ?? SYSTEMS.pythagorean.values;
+  return map[letter] ?? 0;
+}
+
+function calculateNameNumber(name, system, filterFn = () => true) {
+  const letters = sanitizeLetters(name).split('').filter(filterFn);
+  const total = letters.reduce((sum, letter) => sum + letterValue(letter, system), 0);
+  return reduceNumber(total);
+}
+
+function isVowel(letter, word) {
+  if ('AEIOU'.includes(letter)) {
+    return true;
+  }
+  if (letter !== 'Y') {
+    return false;
+  }
+  const hasStandardVowel = word.split('').some((char) => 'AEIOU'.includes(char));
+  return !hasStandardVowel;
+}
+
+function calculateLifePath(date) {
+  if (!date) return null;
+  const digits = date.getFullYear().toString() + (date.getMonth() + 1).toString().padStart(2, '0') + date.getDate().toString().padStart(2, '0');
+  return reduceNumber(Number(digits));
+}
+
+function calculateBirthDay(date) {
+  if (!date) return null;
+  return reduceNumber(date.getDate());
+}
+
+function calculateExpression(name, system) {
+  return calculateNameNumber(name, system);
+}
+
+function calculateHeartsDesire(name, system) {
+  const words = (sanitizeLetters(name) ? name.toUpperCase().split(/[^A-Z]+/) : []);
+  const vowels = [];
+  words.forEach((word) => {
+    const cleaned = sanitizeLetters(word);
+    cleaned.split('').forEach((letter) => {
+      if (isVowel(letter, cleaned)) {
+        vowels.push(letter);
+      }
+    });
+  });
+  const total = vowels.reduce((sum, letter) => sum + letterValue(letter, system), 0);
+  return reduceNumber(total);
+}
+
+function calculatePersonality(name, system) {
+  const words = (sanitizeLetters(name) ? name.toUpperCase().split(/[^A-Z]+/) : []);
+  const consonants = [];
+  words.forEach((word) => {
+    const cleaned = sanitizeLetters(word);
+    cleaned.split('').forEach((letter) => {
+      if (!isVowel(letter, cleaned)) {
+        consonants.push(letter);
+      }
+    });
+  });
+  const total = consonants.reduce((sum, letter) => sum + letterValue(letter, system), 0);
+  return reduceNumber(total);
+}
+
+function calculateUniversalYear(targetDate) {
+  if (!targetDate) return null;
+  return reduceNumber(targetDate.getFullYear());
+}
+
+function calculateUniversalMonth(targetDate) {
+  if (!targetDate) return null;
+  const universalYear = calculateUniversalYear(targetDate);
+  return reduceNumber(universalYear + (targetDate.getMonth() + 1));
+}
+
+function calculatePersonalYear(birthDate, targetDate) {
+  if (!birthDate || !targetDate) return null;
+  const birthMonth = birthDate.getMonth() + 1;
+  const birthDay = birthDate.getDate();
+  const universalYear = calculateUniversalYear(targetDate);
+  return reduceNumber(birthMonth + birthDay + universalYear);
+}
+
+function calculatePersonalMonth(birthDate, targetDate) {
+  if (!birthDate || !targetDate) return null;
+  const personalYear = calculatePersonalYear(birthDate, targetDate);
+  return reduceNumber(personalYear + (targetDate.getMonth() + 1));
+}
+
+function calculateLifePathOfDay(birthDate, targetDate) {
+  if (!birthDate || !targetDate) return null;
+  const personalMonth = calculatePersonalMonth(birthDate, targetDate);
+  return reduceNumber(personalMonth + targetDate.getDate());
+}
+
+function calculateSelectedDateLabel(date) {
+  if (!date) return '—';
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    weekday: 'long'
+  });
+  return formatter.format(date);
+}
+
+export {
+  SYSTEMS,
+  reduceNumber,
+  calculateLifePath,
+  calculateBirthDay,
+  calculateExpression,
+  calculateHeartsDesire,
+  calculatePersonality,
+  calculateUniversalYear,
+  calculateUniversalMonth,
+  calculatePersonalYear,
+  calculatePersonalMonth,
+  calculateLifePathOfDay,
+  calculateSelectedDateLabel
+};


### PR DESCRIPTION
## Summary
- add a static numerology dashboard with inputs for profile and calendar selections
- style the layout with a minimalist card-based design and responsive spacing
- implement numerology calculation utilities and client-side bindings for live updates

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e431ec2700832594f3c22e9c4fe8a0