### PR TITLE
Normalize letters before numerology calculations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "numerology",
+  "version": "0.0.0",
+  "description": "Numerology calculations and utilities",
+  "main": "src/numerology/calculations.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/src/numerology/calculations.js
+++ b/src/numerology/calculations.js
@@ -1,0 +1,138 @@
+const PYTHAGOREAN_TABLE = {
+  A: 1,
+  B: 2,
+  C: 3,
+  D: 4,
+  E: 5,
+  F: 6,
+  G: 7,
+  H: 8,
+  I: 9,
+  J: 1,
+  K: 2,
+  L: 3,
+  M: 4,
+  N: 5,
+  O: 6,
+  P: 7,
+  Q: 8,
+  R: 9,
+  S: 1,
+  T: 2,
+  U: 3,
+  V: 4,
+  W: 5,
+  X: 6,
+  Y: 7,
+  Z: 8
+};
+
+const CHALDEAN_TABLE = {
+  A: 1,
+  B: 2,
+  C: 3,
+  D: 4,
+  E: 5,
+  F: 8,
+  G: 3,
+  H: 5,
+  I: 1,
+  J: 1,
+  K: 2,
+  L: 3,
+  M: 4,
+  N: 5,
+  O: 7,
+  P: 8,
+  Q: 1,
+  R: 2,
+  S: 3,
+  T: 4,
+  U: 6,
+  V: 6,
+  W: 6,
+  X: 5,
+  Y: 1,
+  Z: 7
+};
+
+const ASCII_FALLBACKS = {
+  Æ: "AE",
+  æ: "ae",
+  Ă: "A",
+  ă: "a",
+  Ą: "A",
+  ą: "a",
+  Ç: "C",
+  ç: "c",
+  Đ: "D",
+  đ: "d",
+  Ğ: "G",
+  ğ: "g",
+  Ł: "L",
+  ł: "l",
+  Ń: "N",
+  ń: "n",
+  Ő: "O",
+  ő: "o",
+  Œ: "OE",
+  œ: "oe",
+  Ø: "O",
+  ø: "o",
+  Ś: "S",
+  ś: "s",
+  Ş: "S",
+  ş: "s",
+  Ť: "T",
+  ť: "t",
+  Ź: "Z",
+  ź: "z",
+  Ż: "Z",
+  ż: "z",
+  Þ: "TH",
+  þ: "th",
+  Ð: "D",
+  ð: "d",
+  ß: "ss"
+};
+
+function sanitizeLetters(value) {
+  if (!value) {
+    return "";
+  }
+
+  const stripped = value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^\x00-\x7F]/g, (char) => ASCII_FALLBACKS[char] ?? "");
+
+  return stripped.toUpperCase().replace(/[^A-Z]/g, "");
+}
+
+function calculateTotal(value, table) {
+  const letters = sanitizeLetters(value);
+
+  let total = 0;
+  for (const letter of letters) {
+    const mapped = table[letter];
+    if (mapped) {
+      total += mapped;
+    }
+  }
+
+  return total;
+}
+
+function calculatePythagoreanTotal(value) {
+  return calculateTotal(value, PYTHAGOREAN_TABLE);
+}
+
+function calculateChaldeanTotal(value) {
+  return calculateTotal(value, CHALDEAN_TABLE);
+}
+
+module.exports = {
+  sanitizeLetters,
+  calculatePythagoreanTotal,
+  calculateChaldeanTotal
+};

--- a/test/calculations.test.js
+++ b/test/calculations.test.js
@@ -1,0 +1,49 @@
+const assert = require('assert/strict');
+const test = require('node:test');
+
+const {
+  sanitizeLetters,
+  calculatePythagoreanTotal,
+  calculateChaldeanTotal
+} = require('../src/numerology/calculations');
+
+test('sanitizeLetters removes accents and non-letter characters', () => {
+  assert.equal(sanitizeLetters('Élodie Noël'), 'ELODIENOEL');
+  assert.equal(sanitizeLetters("François D'Amour"), 'FRANCOISDAMOUR');
+  assert.equal(sanitizeLetters('Łukasz Żółć'), 'LUKASZZOLC');
+  assert.equal(sanitizeLetters('Señorita'), 'SENORITA');
+});
+
+test('pythagorean totals account for accented characters', () => {
+  const fixtures = [
+    { value: 'Élodie Noël', total: 51 },
+    { value: "François D'Amour", total: 67 },
+    { value: 'Łukasz Żółć', total: 38 },
+    { value: 'Señorita', total: 38 }
+  ];
+
+  for (const fixture of fixtures) {
+    assert.equal(
+      calculatePythagoreanTotal(fixture.value),
+      fixture.total,
+      `Expected ${fixture.value} to total ${fixture.total} in Pythagorean system`
+    );
+  }
+});
+
+test('chaldean totals account for accented characters', () => {
+  const fixtures = [
+    { value: 'Élodie Noël', total: 45 },
+    { value: "François D'Amour", total: 54 },
+    { value: 'Łukasz Żółć', total: 42 },
+    { value: 'Señorita', total: 28 }
+  ];
+
+  for (const fixture of fixtures) {
+    assert.equal(
+      calculateChaldeanTotal(fixture.value),
+      fixture.total,
+      `Expected ${fixture.value} to total ${fixture.total} in Chaldean system`
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add project scaffolding with a node-based numerology calculation module
- normalize and sanitize letters with Unicode diacritic removal and ASCII fallbacks before summing values
- add node:test fixtures covering accented names for both Pythagorean and Chaldean totals

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e523bd9d3c8325b3d588f2560f2038