### PR TITLE
Refine numerology vowel handling and add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "numerology",
+  "version": "1.0.0",
+  "description": "Numerology calculations",
+  "main": "src/numerology/calculations.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/src/numerology/calculations.js
+++ b/src/numerology/calculations.js
@@ -1,0 +1,175 @@
+const ALPHA_REGEX = /[A-Z]/;
+const STANDARD_VOWELS = new Set(['A', 'E', 'I', 'O', 'U']);
+const MASTER_NUMBERS = new Set([11, 22, 33]);
+const DIPHTHONG_WITH_Y = new Set(['AY', 'EY', 'IY', 'OY', 'UY']);
+const VOWEL_WITH_W = new Set(['AW', 'EW', 'IW', 'OW', 'UW']);
+
+function isLetter(char) {
+  return typeof char === 'string' && char.length === 1 && ALPHA_REGEX.test(char);
+}
+
+function findPreviousLetter(source, index) {
+  for (let i = index - 1; i >= 0; i -= 1) {
+    const candidate = source[i]?.toUpperCase();
+    if (isLetter(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function findNextLetter(source, index) {
+  for (let i = index + 1; i < source.length; i += 1) {
+    const candidate = source[i]?.toUpperCase();
+    if (isLetter(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function letterToNumber(letter) {
+  const value = letter.toUpperCase().charCodeAt(0) - 64;
+  return ((value - 1) % 9) + 1;
+}
+
+function reduceNumber(number) {
+  let total = number;
+  while (total > 9 && !MASTER_NUMBERS.has(total)) {
+    total = total
+      .toString()
+      .split('')
+      .reduce((acc, digit) => acc + Number(digit), 0);
+  }
+  return total;
+}
+
+function isVowel(letter, index = 0, source = letter ?? '') {
+  if (!letter) {
+    return false;
+  }
+
+  const upper = letter.toUpperCase();
+
+  if (!isLetter(upper)) {
+    return false;
+  }
+
+  if (STANDARD_VOWELS.has(upper)) {
+    return true;
+  }
+
+  const previous = findPreviousLetter(source, index);
+  const next = findNextLetter(source, index);
+  const prevIsVowel = previous ? STANDARD_VOWELS.has(previous) : false;
+  const nextIsVowel = next ? STANDARD_VOWELS.has(next) : false;
+  const prevIsConsonant = previous ? !STANDARD_VOWELS.has(previous) : false;
+  const nextIsConsonant = next ? !STANDARD_VOWELS.has(next) : false;
+
+  if (upper === 'Y') {
+    if (!previous) {
+      return !next;
+    }
+
+    if (!next) {
+      return true;
+    }
+
+    if (prevIsVowel) {
+      const pair = `${previous}${upper}`;
+      if (DIPHTHONG_WITH_Y.has(pair)) {
+        return true;
+      }
+      if (nextIsVowel) {
+        return false;
+      }
+    }
+
+    if (prevIsConsonant && nextIsConsonant) {
+      return true;
+    }
+
+    if (prevIsConsonant && nextIsVowel) {
+      return true;
+    }
+
+    if (prevIsVowel && nextIsConsonant) {
+      const pair = `${previous}${upper}`;
+      if (DIPHTHONG_WITH_Y.has(pair)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  if (upper === 'W') {
+    if (!previous) {
+      return false;
+    }
+
+    if (prevIsVowel) {
+      const pair = `${previous}${upper}`;
+      if (VOWEL_WITH_W.has(pair)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  return false;
+}
+
+function sanitizeName(name) {
+  return String(name ?? '').replace(/[^A-Za-z]/g, '');
+}
+
+function accumulateByPredicate(name, predicate) {
+  const source = name.toUpperCase();
+  let total = 0;
+
+  for (let i = 0; i < source.length; i += 1) {
+    const char = source[i];
+
+    if (!isLetter(char)) {
+      continue;
+    }
+
+    if (predicate(char, i, source)) {
+      total += letterToNumber(char);
+    }
+  }
+
+  return total;
+}
+
+function calculateHeartsDesire(name) {
+  const cleaned = sanitizeName(name ?? '');
+  if (!cleaned) {
+    return 0;
+  }
+
+  const total = accumulateByPredicate(cleaned, (char, index, source) =>
+    isVowel(char, index, source),
+  );
+  return reduceNumber(total);
+}
+
+function calculatePersonality(name) {
+  const cleaned = sanitizeName(name ?? '');
+  if (!cleaned) {
+    return 0;
+  }
+
+  const total = accumulateByPredicate(cleaned, (char, index, source) =>
+    !isVowel(char, index, source),
+  );
+  return reduceNumber(total);
+}
+
+module.exports = {
+  isVowel,
+  calculateHeartsDesire,
+  calculatePersonality,
+};

--- a/tests/calculations.test.js
+++ b/tests/calculations.test.js
@@ -1,0 +1,72 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  isVowel,
+  calculateHeartsDesire,
+  calculatePersonality,
+} = require('../src/numerology/calculations');
+
+test('isVowel expands Y guidance', () => {
+  const mary = 'Mary';
+  assert.equal(isVowel(mary[3], 3, mary), true, 'Y at the end of Mary should be vowel');
+
+  const bryan = 'Bryan';
+  assert.equal(isVowel(bryan[2], 2, bryan), true, 'Y between consonant and vowel should count as vowel');
+
+  const gwyneth = 'Gwyneth';
+  assert.equal(isVowel(gwyneth[2], 2, gwyneth), true, 'Y between consonants should count as vowel');
+
+  const maya = 'Maya';
+  assert.equal(isVowel(maya[2], 2, maya), true, 'Y forming diphthong should be vowel');
+
+  const yvonne = 'Yvonne';
+  assert.equal(isVowel(yvonne[0], 0, yvonne), false, 'Leading Y before vowel acts as consonant');
+});
+
+test('isVowel allows W to ally with vowels', () => {
+  const owen = 'Owen';
+  assert.equal(isVowel(owen[1], 1, owen), true, 'W in Owen partners with preceding vowel');
+
+  const william = 'William';
+  assert.equal(isVowel(william[0], 0, william), false, 'Leading W before vowel remains consonant');
+
+  const howard = 'Howard';
+  assert.equal(isVowel(howard[2], 2, howard), true, 'W in Howard works with the O vowel');
+});
+
+test('calculateHeartsDesire honours nuanced vowel rules', () => {
+  const cases = [
+    ['Mary', 8],
+    ['Bryan', 8],
+    ['Gwyneth', 3],
+    ['Lynne', 3],
+    ['Owen', 7],
+  ];
+
+  for (const [name, expected] of cases) {
+    assert.equal(
+      calculateHeartsDesire(name),
+      expected,
+      `Expected hearts desire for ${name} to be ${expected}`,
+    );
+  }
+});
+
+test('calculatePersonality remains in sync with vowel logic', () => {
+  const cases = [
+    ['Mary', 4],
+    ['Bryan', 7],
+    ['Gwyneth', 9],
+    ['Lynne', 4],
+    ['Owen', 5],
+  ];
+
+  for (const [name, expected] of cases) {
+    assert.equal(
+      calculatePersonality(name),
+      expected,
+      `Expected personality for ${name} to be ${expected}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- expand the `isVowel` helper to capture numerology rules for Y and W contexts
- reuse the shared vowel logic inside heart's desire and personality calculations
- add node-based regression tests for tricky names to keep the calculators aligned

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e523bd0b8883258e9938beca717ccf